### PR TITLE
Fix: Add Pydantic Model Reconstruction for A2A Framework Compatibility

### DIFF
--- a/src/a2a_redis/model_utils.py
+++ b/src/a2a_redis/model_utils.py
@@ -1,0 +1,64 @@
+"""Utilities for handling Pydantic model serialization/deserialization in Redis queues."""
+
+import json
+from typing import Any, Union, Optional
+import a2a.types
+
+
+def serialize_event(event: Any) -> dict:
+    """Serialize an event to a dictionary structure for Redis storage.
+    
+    Args:
+        event: Event object to serialize
+        
+    Returns:
+        Dictionary with event_type and event_data
+    """
+    if hasattr(event, "model_dump"):
+        event_data = event.model_dump()
+    else:
+        event_data = event
+    
+    return {
+        "event_type": type(event).__name__,
+        "event_data": event_data
+    }
+
+
+def deserialize_event(event_structure: dict) -> Any:
+    """Deserialize an event from a dictionary structure back to a Pydantic model.
+    
+    Args:
+        event_structure: Dictionary containing event_type and event_data
+        
+    Returns:
+        Reconstructed Pydantic model instance or raw data as fallback
+    """
+    if not isinstance(event_structure, dict) or "event_data" not in event_structure:
+        return event_structure
+    
+    event_data = event_structure["event_data"]
+    event_type = event_structure.get("event_type")
+    
+    # Re-construct the Pydantic model if type info is available
+    if event_type and hasattr(a2a.types, event_type):
+        ModelClass = getattr(a2a.types, event_type)
+        try:
+            return ModelClass(**event_data)
+        except Exception:
+            # Fallback if model reconstruction fails
+            return event_data
+    
+    return event_data
+
+
+def serialize_to_json(data: dict, **json_kwargs) -> str:
+    """Serialize dictionary to JSON string with default str conversion."""
+    return json.dumps(data, default=str, **json_kwargs)
+
+
+def deserialize_from_json(json_str: Union[str, bytes]) -> dict:
+    """Deserialize JSON string/bytes to dictionary."""
+    if isinstance(json_str, bytes):
+        json_str = json_str.decode()
+    return json.loads(json_str)

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import AsyncMock
+from a2a.types import Message, Task, TaskStatusUpdateEvent
+from a2a_redis.model_utils import serialize_event, deserialize_event
+from a2a_redis import RedisStreamsEventQueue, RedisPubSubEventQueue
+
+
+@pytest.mark.asyncio
+async def test_message_serialization_roundtrip():
+    """Test that Message objects survive serialization/deserialization."""
+    original_message = Message(
+        messageId="test-123",
+        role="user", 
+        parts=[{"kind": "text", "text": "Hello"}],
+        kind="message"
+    )
+    
+    # Serialize then deserialize
+    serialized = serialize_event(original_message)
+    reconstructed = deserialize_event(serialized)
+    
+    # Should be same type and data
+    assert type(reconstructed) == type(original_message)
+    assert reconstructed.messageId == original_message.messageId
+    assert reconstructed.role == original_message.role
+
+
+@pytest.mark.asyncio 
+async def test_streams_queue_pydantic_model_preservation():
+    """Test that Redis Streams queue preserves Pydantic models."""
+    redis_mock = AsyncMock()
+    redis_mock.xadd = AsyncMock()
+    redis_mock.xreadgroup = AsyncMock(return_value=[
+        ["stream:test", [[b"123-0", {b"event_type": b"Message", b"event_data": b'{"messageId": "test", "role": "user", "parts": [], "kind": "message"}'}]]]
+    ])
+    
+    queue = RedisStreamsEventQueue(redis_mock, "test")
+    result = await queue.dequeue_event()
+    
+    # Should return actual Message instance, not dict
+    assert isinstance(result, Message)
+    assert result.messageId == "test"


### PR DESCRIPTION
Fix: Add Pydantic Model Reconstruction for A2A Framework Compatibility

Problem:
The existing a2a-redis implementations (both RedisStreamsEventQueue and RedisPubSubEventQueue) serialize Pydantic models to JSON correctly but only return raw dictionaries during deserialization. The A2A framework's EventConsumer expects actual Pydantic model instances, not dictionaries.

This causes the A2A framework's EventConsumer to hang indefinitely during event processing. Upon dequeue, only raw Python dictionaries are returned instead of reconstructing the original Pydantic model instances. The A2A framework's EventConsumer.consume_all() method relies on isinstance() checks and attribute access on Pydantic models to determine when to stop consuming events.

Changes:
- New `model_utils.py` with serialization helpers
- Updated Redis Streams queue for model reconstruction  
- Updated Redis Pub/Sub queue for model reconstruction

Fixes #2