### PR TITLE
fix: close(immediate) and dequeue_event exceptions for EventConsumer compatibility

### DIFF
--- a/src/a2a_redis/streams_queue.py
+++ b/src/a2a_redis/streams_queue.py
@@ -67,6 +67,10 @@ class RedisStreamsEventQueue:
         self.redis = redis_client
         self.task_id = task_id
         self.prefix = prefix
+        # close() semantics:
+        # - close(immediate=False): producer shutdown (stop enqueue; consumers may drain)
+        # - close(immediate=True): consumer shutdown (stop dequeue; used by EventConsumer on final event)
+        self._closing = False
         self._closed = False
         self._stream_key = f"{prefix}{task_id}"
 
@@ -101,8 +105,10 @@ class RedisStreamsEventQueue:
         Raises:
             RuntimeError: If queue is closed
         """
-        if self._closed:
-            raise RuntimeError("Cannot enqueue to closed queue")
+        if self._closing or self._closed:
+            # a2a-sdk closes the queue after agent run; reject new enqueues
+            # while allowing consumers to drain already-enqueued events.
+            raise RuntimeError("Cannot enqueue to closing/closed queue")
 
         # Ensure consumer group exists on first use
         if not self._consumer_group_ensured:
@@ -132,8 +138,9 @@ class RedisStreamsEventQueue:
             Reconstructed Pydantic model (Message, Task, TaskStatusUpdateEvent, or TaskArtifactUpdateEvent)
 
         Raises:
-            asyncio.QueueEmpty: If queue is closed (for compatibility with a2a-sdk EventConsumer)
-            RuntimeError: If no events available or other errors occur
+            asyncio.QueueEmpty: If no events are available or queue is closed.
+            asyncio.TimeoutError: If no events within block timeout (no_wait=False).
+              Matches a2a-sdk EventConsumer expectations.
         """
         if self._closed:
             raise asyncio.QueueEmpty("Queue is closed")
@@ -144,7 +151,7 @@ class RedisStreamsEventQueue:
             self._consumer_group_ensured = True
 
         # Read from consumer group
-        timeout = 0 if no_wait else 1000  # 0 = non-blocking, 1000ms = 1 second timeout
+        timeout = 0 if no_wait else 1000  # 0 = non-blocking, 1000ms block
 
         try:
             # XREADGROUP GROUP group_name consumer_id COUNT 1 BLOCK timeout STREAMS stream_key >
@@ -157,7 +164,15 @@ class RedisStreamsEventQueue:
             )  # type: ignore[misc]
 
             if not result or not result[0][1]:  # No messages available
-                raise RuntimeError("No events available")
+                # If producer has signaled close and there are no messages, mark closed and stop consumer.
+                if self._closing:
+                    self._closed = True
+                    raise asyncio.QueueEmpty("Queue is closed")
+                # No events: raise so EventConsumer can continue polling or exit by contract.
+                if no_wait:
+                    # EventConsumer.consume_one() expects QueueEmpty when no_wait and no events.
+                    raise asyncio.QueueEmpty("No events available")
+                raise asyncio.TimeoutError("No events available")
 
             # Extract message data
             _, messages = result[0]
@@ -177,37 +192,54 @@ class RedisStreamsEventQueue:
             # Reconstruct the actual Pydantic model using shared utility
             return deserialize_event(event_structure)
 
+        except (asyncio.TimeoutError, TimeoutError, asyncio.QueueEmpty):
+            # Re-raise so EventConsumer handles them as control-flow exceptions.
+            raise
         except Exception as e:  # type: ignore[misc]
             if "NOGROUP" in str(e):
                 # Consumer group was deleted, recreate it
                 await self._ensure_consumer_group()
-                raise RuntimeError("Consumer group recreated, try again")
-            raise RuntimeError(f"Error reading from stream: {e}")
+                if no_wait:
+                    raise asyncio.QueueEmpty(
+                        "Consumer group recreated, try again"
+                    ) from e
+                raise asyncio.TimeoutError("Consumer group recreated, try again") from e
+            raise RuntimeError(f"Error reading from stream: {e}") from e
 
-    async def close(self) -> None:
-        """Close the queue and clean up pending messages."""
-        self._closed = True
-        # Optionally clean up pending messages for this consumer
+    async def close(self, immediate: bool = False) -> None:
+        """Close the queue.
+
+        Args:
+            immediate:
+              - False (default): Stop enqueue; set _closing so consumers can drain.
+              - True: Stop dequeue (used by a2a-sdk EventConsumer on final event).
+                Set _closed and run pending cleanup (xpending_range + xack for this consumer).
+        """
+        if immediate:
+            self._closed = True
+            await self._close_pending_cleanup()
+            return
+
+        self._closing = True
+
+    async def _close_pending_cleanup(self) -> None:
+        """Ack this consumer's pending messages (xpending_range + xack) for cleanup."""
         try:
-            # Get pending messages for this consumer
-            pending = await self.redis.xpending_range(  # type: ignore[misc]
+            pending = await self.redis.xpending_range(
                 self._stream_key,
                 self.consumer_group,
                 min="-",
                 max="+",
                 count=100,
                 consumername=self.consumer_id,
-            )
-
-            # Acknowledge any pending messages to prevent them from being stuck
+            )  # type: ignore[misc]
             if pending:
                 message_ids = [msg["message_id"] for msg in pending]
                 await self.redis.xack(
                     self._stream_key, self.consumer_group, *message_ids
                 )  # type: ignore[misc]
-
         except Exception:  # type: ignore[misc]
-            # Consumer group might not exist, ignore
+            # Ignore e.g. NOGROUP (consumer group missing) so close() completes without raising.
             pass
 
     def is_closed(self) -> bool:

--- a/src/a2a_redis/streams_queue.py
+++ b/src/a2a_redis/streams_queue.py
@@ -151,7 +151,7 @@ class RedisStreamsEventQueue:
             self._consumer_group_ensured = True
 
         # Read from consumer group
-        timeout = 0 if no_wait else 1000  # 0 = non-blocking, 1000ms block
+        timeout = 0 if no_wait else 1000  # 0 = non-blocking, 1000ms = 1 second timeout
 
         try:
             # XREADGROUP GROUP group_name consumer_id COUNT 1 BLOCK timeout STREAMS stream_key >

--- a/src/a2a_redis/streams_queue_manager.py
+++ b/src/a2a_redis/streams_queue_manager.py
@@ -64,7 +64,7 @@ class RedisStreamsQueueManager(QueueManager):
             task_id: Task identifier
         """
         if task_id in self._queues:
-            await self._queues[task_id].close()
+            await self._queues[task_id].close(immediate=True)  # full close and pending cleanup
             del self._queues[task_id]
 
     async def create_or_tap(self, task_id: str) -> EventQueueProtocol:  # type: ignore[override]

--- a/tests/test_streams_queue_manager.py
+++ b/tests/test_streams_queue_manager.py
@@ -204,7 +204,7 @@ class TestRedisStreamsEventQueue:
 
     @pytest.mark.asyncio
     async def test_close_queue(self, mock_redis):
-        """Test closing the queue."""
+        """Test closing the queue with immediate=True (full close + pending cleanup)."""
         queue = RedisStreamsEventQueue(mock_redis, "task_123")
 
         # Mock pending messages
@@ -213,7 +213,7 @@ class TestRedisStreamsEventQueue:
             {"message_id": b"124-0"},
         ]
 
-        await queue.close()
+        await queue.close(immediate=True)
 
         assert queue._closed
         # Verify pending messages were acknowledged
@@ -281,7 +281,7 @@ class TestRedisStreamsEventQueue:
         mock_redis.xpending_range.side_effect = Exception("NOGROUP")
 
         # Should not raise - exception is caught and ignored
-        await queue.close()
+        await queue.close(immediate=True)
         assert queue._closed
 
     @pytest.mark.asyncio
@@ -292,7 +292,7 @@ class TestRedisStreamsEventQueue:
         # No pending messages
         mock_redis.xpending_range.return_value = []
 
-        await queue.close()
+        await queue.close(immediate=True)
         assert queue._closed
         # xack should not be called when no pending messages
         mock_redis.xack.assert_not_called()


### PR DESCRIPTION
## Summary

Adds `close(immediate: bool)` to `RedisStreamsEventQueue` ( Fixes #11 )
and aligns `dequeue_event()` with EventConsumer (TimeoutError / QueueEmpty). ( Fixes #12 )



## Changes

- **Close**: 
    - `close(immediate=True)` runs pending cleanup (xpending_range + xack); 
    - `immediate=False` sets `_closing` only. 
    - New `_close_pending_cleanup()`; 
    - manager.close() calls `queue.close(immediate=True)`.
- **Dequeue**: 
    - `dequeue_event()` raises `asyncio.TimeoutError` or `asyncio.QueueEmpty` (no RuntimeError wrap).

## Testing

`pytest tests/`